### PR TITLE
Add Mermaid diagram checks

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -31,8 +31,29 @@ defaults:
     shell: bash
 
 jobs:
+  mermaid:
+    name: Check Mermaid diagrams
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check Mermaid diagrams
+        uses: stonecharioteer/check-mmdjs-action@v3.1
+        with:
+          files: |
+            content/**/*.md
+            diagrams/**/*.mmd
+            diagrams/**/*.mermaid
+            README.md
+          ignore: |
+            themes/**
+            public/**
+            node_modules/**
+          mermaid-version: 11.4.1
+
   # Build job
   build:
+    needs: mermaid
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: 0.146.7
@@ -49,19 +70,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Check Mermaid diagrams
-        uses: stonecharioteer/check-mmdjs-action@v3.1
-        with:
-          files: |
-            content/**/*.md
-            diagrams/**/*.mmd
-            diagrams/**/*.mermaid
-            README.md
-          ignore: |
-            themes/**
-            public/**
-            node_modules/**
-          mermaid-version: 11.4.1
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -49,6 +49,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Check Mermaid diagrams
+        uses: stonecharioteer/check-mmdjs-action@v3.1
+        with:
+          files: |
+            content/**/*.md
+            diagrams/**/*.mmd
+            diagrams/**/*.mermaid
+            README.md
+          ignore: |
+            themes/**
+            public/**
+            node_modules/**
+          mermaid-version: 11.4.1
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/content/posts/2026/mermaidjs-check/index.md
+++ b/content/posts/2026/mermaidjs-check/index.md
@@ -1,0 +1,80 @@
+---
+date: "2026-07-01T08:59:10+05:30"
+draft: false
+title: "Checking Mermaid Diagrams in CI"
+description:
+  "I wrote a small GitHub Action to catch broken Mermaid diagrams in Markdown
+  and standalone diagram files before they land in a repository."
+tags:
+  - "automation"
+  - "diagrams"
+  - "github"
+  - "markdown"
+  - "testing"
+---
+
+I have been using Mermaid diagrams more often in repositories. They're great in
+Markdown because the diagram stays close to the explanation, and they're also
+nice as standalone `.mmd` files when the diagram starts to deserve its own file.
+
+The annoying bit is that Mermaid syntax errors are easy to miss. A README can
+look fine until someone opens the exact section with the broken diagram, or a
+blog post can build successfully while the rendered diagram is wrong. I wanted a
+small CI check for that, so I wrote
+[`check-mmdjs-action`][check-mmdjs-action].
+
+The action checks three common cases:
+
+- fenced Mermaid blocks in Markdown files,
+- standalone `.mmd` files,
+- standalone `.mermaid` files.
+
+It uses Mermaid's parser API for syntax validation. It does not render diagrams,
+and it does not launch Chrome or Puppeteer. That matters because I only want CI
+to answer one question: "is this diagram valid Mermaid?" Rendering failures and
+browser setup failures should not be confused with syntax failures.
+
+A minimal workflow looks like this:
+
+```yaml
+name: Check Mermaid diagrams
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  mermaid:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: stonecharioteer/check-mmdjs-action@v3.1
+```
+
+For this blog, I configured it more narrowly. I only need to scan the Markdown
+content and the `diagrams/` directory:
+
+```yaml
+- name: Check Mermaid diagrams
+  uses: stonecharioteer/check-mmdjs-action@v3.1
+  with:
+    files: |
+      content/**/*.md
+      diagrams/**/*.mmd
+      diagrams/**/*.mermaid
+      README.md
+    ignore: |
+      themes/**
+      public/**
+      node_modules/**
+    mermaid-version: 11.4.1
+```
+
+That is now part of the Hugo workflow for this site. If I add a broken Mermaid
+fence to a post or commit an invalid standalone diagram, the pull request should
+fail before the bad diagram reaches the blog.
+
+This is a tiny piece of automation, but it is exactly the kind I like: boring,
+focused, and close to where the mistake happens.
+
+[check-mmdjs-action]: https://github.com/stonecharioteer/check-mmdjs-action


### PR DESCRIPTION
## Summary
- publish a short post about check-mmdjs-action
- add the Mermaid diagram check to the Hugo workflow
- scan blog Markdown and standalone diagram files with v3.1

## Validation
- hugo --minify