### PR TITLE
post(wip): What I See + site author params

### DIFF
--- a/content/posts/2026/what-i-see.md
+++ b/content/posts/2026/what-i-see.md
@@ -1,0 +1,30 @@
+---
+date: "2026-06-20T13:50:07+05:30"
+draft: true
+title: "What I See"
+description: ""
+tags:
+  - "taste"
+---
+
+{{< quote title="On Taste" footer="Ira Glass" >}} Nobody tells this to people
+who are beginners, I wish someone told me. All of us who do creative work, we
+get into it because we have good taste. But there is this gap. For the first
+couple years you make stuff, it's just not that good. It's trying to be good, it
+has potential, but it's not. But your taste, the thing that got you into the
+game, is still killer. And your taste is why your work disappoints you. A lot of
+people never get past this phase, they quit. Most people I know who do
+interesting, creative work went through years of this. We know our work doesn't
+have this special thing that we want it to have. We all go through this. And if
+you are just starting out or you are still in this phase, you gotta know it's
+normal and the most important thing you can do is do a lot of work. Put yourself
+on a deadline so that every week you will finish one story. It is only by going
+through a volume of work that you will close that gap, and your work will be as
+good as your ambitions. And I took longer to figure out how to do this than
+anyone I've ever met. It's gonna take a while. It's normal to take a while.
+You've just gotta fight your way through. {{< /quote >}}
+
+I read this quote in the Zen Pencils website back in the day, and it's stuck
+with me for a very long time.
+
+Six months ago, I'd quit Chatwoot and didn't know what I wanted to do next.

--- a/hugo.yml
+++ b/hugo.yml
@@ -43,6 +43,8 @@ markup:
     lineNumbersInTable: true
     noClasses: false
 params:
+  author:
+    name: "Vinay Keerthi"
   images:
     - /logo/stonecharioteer-og.png
   env: production


### PR DESCRIPTION
## Summary
- Start a draft post **What I See** (`content/posts/2026/what-i-see.md`) with Ira Glass's quote on taste and opening notes
- Set `params.author.name` to `"Vinay Keerthi"` in `hugo.yml`

## Notes
- Post is still `draft: true` and incomplete
- Kept scope narrow: only the post draft + author params change

## Test plan
- [ ] `hugo serve --buildDrafts` and open `/posts/2026/what-i-see/`
- [ ] Confirm the quote admonition renders with attribution
- [ ] Confirm author metadata appears where expected from Hugo params